### PR TITLE
Web build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ or link to it from a CDN:
 <script src=https://cdn.jsdelivr.net/npm/tex-math-parser></script>
 ```
 
+There are three build outputs included. At `dist/index.js` is the standard CJS entry point (default if loaded as a package). At `dist/module/index.js` is the packed ES6 module entry point (default if loaded as a module). At `dist/browser/index.js` is the packed global variable entry point. The latter two can be utilized in a web browser directly, whereas the former would require a CJS loader to be utilized.
+
 ## Usage
 
 Given the following TeX source string:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "tsc --watch",
     "start": "tsc --watch",
+    "prepare": "npm run build",
     "build-node": "tsc",
     "start-web": "npx webpack-dev-server --mode development",
     "build-web": "npx webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "start": "tsc --watch",
     "build-node": "tsc",
     "start-web": "npx webpack-dev-server --mode development",
-    "build-web": "npx webpack --mode production",
+    "build-web": "npx webpack --mode production && cp dist/browser/index.js.LICENSE.txt dist/module",
     "build": "npm run build-node && npm run build-web",
     "lint": "npx eslint",
     "test": "npx jest"
   },
   "main": "dist/index.js",
+  "module": "dist/module/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "tsc --watch",
     "build-node": "tsc",
     "start-web": "npx webpack-dev-server --mode development",
-    "build-web": "npx webpack --mode production && cp dist/browser/index.js.LICENSE.txt dist/module",
+    "build-web": "npx webpack --mode production",
     "build": "npm run build-node && npm run build-web",
     "lint": "npx eslint",
     "test": "npx jest"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "scripts": {
     "dev": "tsc --watch",
     "start": "tsc --watch",
+    "build-node": "tsc",
+    "start-web": "npx webpack-dev-server --mode development",
+    "build-web": "npx webpack --mode production",
+    "build": "npm run build-node && npm run build-web",
     "lint": "npx eslint",
     "test": "npx jest"
   },
@@ -49,6 +53,9 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.3"
+    "ts-loader": "^9.4.2",
+    "typescript": "^5.4.3",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^6.0.1"
   }
 }

--- a/tsconfig.es6.json
+++ b/tsconfig.es6.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "ES6",
+    "moduleResolution": "node",
+    "target": "es6",
+    "declaration": true,
+    "outDir": "./dist",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*",
+    "types/**/*"
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,28 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.ts',
+  module: {
+    rules: [
+      {
+        test: /\.ts?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  output: {
+    filename: 'index.js',
+    library: 'texmp',
+    path: path.resolve(__dirname, 'dist/browser'),
+  },
+  devServer: {
+    static: path.join(__dirname, "dist/browser"),
+    compress: false,
+    port: 4000,
+  },
+  devtool: "source-map",
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,19 @@
 const path = require('path');
 
-module.exports = {
+const generalConfig = {
   entry: './src/index.ts',
   module: {
     rules: [
       {
         test: /\.ts?$/,
-        use: 'ts-loader',
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              configFile: 'tsconfig.es6.json',
+            },
+          },
+        ],
         exclude: /node_modules/,
       },
     ],
@@ -14,11 +21,9 @@ module.exports = {
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
   },
-  output: {
-    filename: 'index.js',
-    library: 'texmp',
-    path: path.resolve(__dirname, 'dist/browser'),
-  },
+  externals: [
+    "mathjs"
+  ],
   devServer: {
     static: path.join(__dirname, "dist/browser"),
     compress: false,
@@ -26,3 +31,26 @@ module.exports = {
   },
   devtool: "source-map",
 };
+
+const browserConfig = {
+  ...generalConfig,
+  output: {
+    filename: 'index.js',
+    library: 'texmp',
+    path: path.resolve(__dirname, 'dist/browser'),
+  },
+}
+
+const moduleConfig = {
+  ...generalConfig,
+  output: {
+    filename: 'index.js',
+    libraryTarget: 'module',
+    path: path.resolve(__dirname, 'dist/module'),
+  },
+  experiments: {
+    outputModule: true,
+  },
+}
+
+module.exports = [browserConfig, moduleConfig];


### PR DESCRIPTION
This is the build target portion of #11 separated out from the feature updates. This makes it easier to build the CJS (Node) module, and adds the capability of building ES6 and browser modules. This uses Webpack to provide the additional targets.